### PR TITLE
Fix title and contact in repo.js

### DIFF
--- a/repo.js
+++ b/repo.js
@@ -1,6 +1,7 @@
 {
     "id": "MoriyaFaith",
-    "title": "@MoriyaFaith#9287",
+    "title": "MoriyaFaith's Improvement and Character Mods",
+    "contact": "@MoriyaFaith#9287",
     "servers": [
         "https://thcrap.nmlgc.net/repos/MoriyaFaith/",
         "http://thcrap.nmlgc.net/repos/MoriyaFaith/",


### PR DESCRIPTION
The current repo.js breaks the update script (which expects to have a `contact` field). Because of this, any update with the broken repo.js would cause a CRC error when people try to use the patch.

This pull request fixes the repo.js file.